### PR TITLE
Use promises and consume job result

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1395,6 +1395,11 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "amqplib": "^0.7.1",
     "body-parser": "^1.19.0",
     "dotenv": "^9.0.2",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "nodemon": "^2.0.7"

--- a/routes/try.route.js
+++ b/routes/try.route.js
@@ -1,37 +1,80 @@
 const bodyParser = require('body-parser');
-const amqp = require('amqplib/callback_api');
-const option = { credentials: require('amqplib').credentials.plain(process.env.RABBITMQ_USER, process.env.RABBITMQ_PASSWD) };
+const amqp = require('amqplib');
+const { v4: uuidv4 } = require('uuid');
+const option = {
+    credentials: require('amqplib').credentials.plain(
+        process.env.RABBITMQ_USER,
+        process.env.RABBITMQ_PASSWD
+    ),
+};
 
 module.exports = function (app) {
-
     app.get('/api', async (req, res) => {
-        res.status(200).json({ message: "Welcome to CodeBench-API"});
+        res.status(200).json({ message: 'Welcome to CodeBench-API' });
     });
 
     app.post('/api/try', bodyParser.json(), async (req, res) => {
-        let data = req.body;
+        const job = req.body;
+        job.id = uuidv4();
 
-        amqp.connect(process.env.RABBITMQ_URL, option, (error0, connection) => {
-            if (error0) {
-                res.status(500).json({ message: "Failed to connect to message broker" });
-            }
-            connection.createChannel(function(error1, channel) {
-                if (error1) {
-                    res.status(500).json({ message: "Failed to send code your code for execution" });
-                }
-                const queue = process.env.RABBITMQ_QUEUE;
+        try {
+            const conn = await amqp.connect(process.env.RABBITMQ_URL, option);
+            const chan = await conn.createChannel();
+            const chan_status = await conn.createChannel();
+            const queue = process.env.RABBITMQ_QUEUE;
 
-                channel.assertQueue(queue, {
-                    durable: true
-                });
-                channel.sendToQueue(queue, Buffer.from(JSON.stringify(data)), {
-                    persistent: true
-                });
+            // Prepare status channel/queue/exchange/whatever
+            chan_status.assertExchange('job_status', 'direct', {
+                durable: false,
             });
-            setTimeout(function() {
-                connection.close();
-                res.status(200).json({ message: "Code successfully sent to message broker" });
-            }, 10);
-        });
+            const status_queue = await chan_status.assertQueue('job_status', {
+                durable: true,
+            });
+            chan_status.bindQueue(status_queue.queue, 'job_status', job.id);
+
+            // Send job to RabbitMQ
+            await chan.assertQueue(queue, {
+                durable: true,
+            });
+
+            await chan.sendToQueue(
+                queue,
+                Buffer.from(JSON.stringify(req.body)),
+                {
+                    persistent: true,
+                }
+            );
+
+            // Wait for job to be processed by getting status from queue
+            await chan_status.consume(status_queue.queue, (msg) => {
+                console.log(msg.content.toString());
+                chan_status.ack(msg);
+                const parsedRes = JSON.parse(msg.content.toString());
+                if (parsedRes.status == 'done') {
+                    res.status(200).json({
+                        message: 'Code successfully sent to message broker',
+                        id: job.id,
+                        stderr: parsedRes.stderr,
+                        stdout: parsedRes.stdout,
+                    });
+                    return;
+                }
+                if (parsedRes.status == 'failed') {
+                    res.status(500).json({
+                        message: 'Failed to send code your code for execution',
+                    });
+                    return;
+                }
+            });
+
+            await chan.close();
+            await chan_status.close();
+            await conn.close();
+        } catch (e) {
+            console.error(e);
+            res.status(500).json({
+                message: 'Failed to send code your code for execution',
+            });
+        }
     });
-}
+};


### PR DESCRIPTION
- Callbacks -> async/await promises
- Consume job status from queue using routing key (https://www.rabbitmq.com/tutorials/tutorial-four-javascript.html) and wait until result or fail
- Send back output of code

Works with https://github.com/codebench-esgi/worker/commit/0b7ea7eedaa6b1ed671489055b952dd2b2d3f483

```sh
 » curl -s -X POST 'localhost:3000/api/try' \
--header 'Content-Type: application/json' \
--data-raw '{
    "id":"666",
    "type": "code",
    "code":"#include <stdio.h>\r\nint main() {\r\n   \/\/ printf() displays the string inside quotation\r\n   printf(\"Hello, World!\");\r\n   return 0;\r\n}"
}' | jq
{
  "message": "Code successfully sent to message broker",
  "id": "733eafb1-19ca-4185-ab52-b374b0d79f71",
  "stderr": "",
  "stdout": "Hello, World!"
}
```